### PR TITLE
Add SSM parameters and Secrets Manager resources (use local RDS/VPC outputs)

### DIFF
--- a/outputs_to_ssm.tf
+++ b/outputs_to_ssm.tf
@@ -1,0 +1,106 @@
+# =============================================================================
+# SSM Parameters & Secrets Manager Outputs
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# EKS Optimized Amazon Linux 2023 AMI (x86_64)
+# -----------------------------------------------------------------------------
+# Uses AWS-owned EKS optimized AMI catalog
+# Reference: amazon-eks-node-al2023-x86_64-standard-*
+# -----------------------------------------------------------------------------
+
+data "aws_ami" "eks_al2023" {
+  most_recent = true
+  owners      = ["602401143452"] # Amazon EKS AMI Account
+
+  filter {
+    name   = "name"
+    values = ["amazon-eks-node-al2023-x86_64-standard-*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "state"
+    values = ["available"]
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Secrets Manager: DB Credentials (shared across services)
+# -----------------------------------------------------------------------------
+resource "aws_secretsmanager_secret" "petclinic_db_credentials" {
+  name = "/petclinic/db_credentials"
+}
+
+resource "aws_secretsmanager_secret_version" "petclinic_db_credentials" {
+  secret_id = aws_secretsmanager_secret.petclinic_db_credentials.id
+  secret_string = jsonencode({
+    CUSTOMERS_DATASOURCE_USERNAME = var.db_username
+    CUSTOMERS_DATASOURCE_PASSWORD = var.db_password
+    VETS_DATASOURCE_USERNAME      = var.db_username
+    VETS_DATASOURCE_PASSWORD      = var.db_password
+    VISITS_DATASOURCE_USERNAME    = var.db_username
+    VISITS_DATASOURCE_PASSWORD    = var.db_password
+  })
+}
+
+# -----------------------------------------------------------------------------
+# SSM Parameters (Standard Tier)
+# -----------------------------------------------------------------------------
+resource "aws_ssm_parameter" "petclinic_db_host" {
+  name  = "/petclinic/db_host"
+  type  = "String"
+  tier  = "Standard"
+  value = aws_db_instance.main.endpoint
+}
+
+resource "aws_ssm_parameter" "petclinic_vpc_id" {
+  name  = "/petclinic/vpc_id"
+  type  = "String"
+  tier  = "Standard"
+  value = module.vpc.vpc_id
+}
+
+resource "aws_ssm_parameter" "petclinic_private_subnets" {
+  name  = "/petclinic/subnets/private"
+  type  = "StringList"
+  tier  = "Standard"
+  value = join(",", module.vpc.app_private_subnet_ids)
+}
+
+resource "aws_ssm_parameter" "petclinic_public_subnets" {
+  name  = "/petclinic/subnets/public"
+  type  = "StringList"
+  tier  = "Standard"
+  value = join(",", module.vpc.public_subnet_ids)
+}
+
+resource "aws_ssm_parameter" "petclinic_karpenter_role_arn" {
+  name  = "/petclinic/karpenter/role_arn"
+  type  = "String"
+  tier  = "Standard"
+  value = module.karpenter.role_arn
+}
+
+resource "aws_ssm_parameter" "petclinic_karpenter_ami_id" {
+  name  = "/petclinic/karpenter/ami_id"
+  type  = "String"
+  tier  = "Standard"
+  value = data.aws_ami.eks_al2023.id
+}
+
+resource "aws_ssm_parameter" "petclinic_aws_account_id" {
+  name  = "/petclinic/aws_account_id"
+  type  = "String"
+  tier  = "Standard"
+  value = data.aws_caller_identity.current.account_id
+}


### PR DESCRIPTION
### Motivation
- Centralize runtime configuration and secrets for the PetClinic deployment in AWS SSM and AWS Secrets Manager.
- Provide a single shared DB credentials secret for all microservices while using the existing local RDS resources in this repo. 
- Expose VPC, subnet lists, Karpenter role/AMI, RDS endpoint, and account ID for bootstrapping and automation.

### Description
- Add a new file `outputs_to_ssm.tf` that creates `aws_secretsmanager_secret` and `aws_secretsmanager_secret_version` at `/petclinic/db_credentials` using `var.db_username` and `var.db_password`.
- Add `data.aws_ami.eks_al2023` to resolve the latest EKS-optimized Amazon Linux 2023 AMI and store the AMI id in SSM at `/petclinic/karpenter/ami_id`.
- Create SSM parameters mapping RDS host to `aws_db_instance.main.endpoint`, VPC ID to `module.vpc.vpc_id`, private subnets to `module.vpc.app_private_subnet_ids`, public subnets to `module.vpc.public_subnet_ids`, Karpenter role to `module.karpenter.role_arn`, and AWS account ID to `data.aws_caller_identity.current.account_id`.
- Replace earlier references to a non-existent `module.db` with the repository's local RDS resources and variables (`aws_db_instance.main`, `var.db_username`, `var.db_password`) and align subnet output names to the `vpc` module outputs.

### Testing
- No automated tests were run for this Terraform-only change.
- It is recommended to run `terraform validate` to check syntax and provider references before planning or applying.
- It is recommended to run `terraform plan` in the workspace to verify the intended changes and any required provider/data dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948d7067c4c832ba433a162b6c731fc)